### PR TITLE
Add Redis cache resource to main.bicep. Revolves #11

### DIFF
--- a/src/InfrastructureAsCode/main.bicep
+++ b/src/InfrastructureAsCode/main.bicep
@@ -13,7 +13,25 @@ var registryName = '${uniqueString(resourceGroup().id)}mpnpreg'
 var registrySku = 'Standard'
 var imageName = 'techexcel/dotnetcoreapp'
 var startupCommand = ''
+var redisCacheName = '${uniqueString(resourceGroup().id)}-mpnp-redis'
+var redisCacheSku = 'Basic'
 
+resource redisCache 'Microsoft.Cache/Redis@2023-08-01' = {
+  name: redisCacheName
+  location: location
+  properties: {
+    sku: {
+      name: redisCacheSku
+      family: 'C'
+      capacity: 0
+    }
+    enableNonSslPort: false
+    minimumTlsVersion: '1.2'
+    redisConfiguration: {
+      'maxmemory-policy': 'volatile-lru'
+    }
+  }
+}
 
 resource logAnalyticsWorkspace 'Microsoft.OperationalInsights/workspaces@2021-12-01-preview' = {
   name: logAnalyticsName


### PR DESCRIPTION
This pull request to `src/InfrastructureAsCode/main.bicep` includes changes to add a Redis Cache resource to the infrastructure. The most important changes are the addition of variables for the Redis Cache name and SKU, and the definition of the Redis Cache resource itself.

### Additions to Infrastructure:

* Added `redisCacheName` and `redisCacheSku` variables to define the Redis Cache name and SKU. (`src/InfrastructureAsCode/main.bicep`)
* Defined a new Redis Cache resource with properties including location, SKU, TLS version, and memory policy configuration. (`src/InfrastructureAsCode/main.bicep`)